### PR TITLE
Adding an implementation of logException to the SplunkStorm transport.

### DIFF
--- a/lib/SplunkStorm.js
+++ b/lib/SplunkStorm.js
@@ -52,7 +52,7 @@ SplunkStorm.prototype.log = function (level, msg, meta, callback) {
 * @param callback {function} Continuation to respond to when complete.
 */
 SplunkStorm.prototype.logException = function (msg, meta, callback) {
-    this.storm.send("Error " + msg, this.options.sourcetype, this.options.host, this.options.source, function(err) {
+    this.storm.send("Exception " + msg, this.options.sourcetype, this.options.host, this.options.source, function(err) {
 
         callback(err, !err)
 


### PR DESCRIPTION
Winston allows you to capture general exceptions and log them. To do this your transport must implement the function named logException. Below is a very simple implementation of that function added to the SplunkStorm transport.
