### PR TITLE
Changed to sending a json-object instead of plain message

### DIFF
--- a/lib/SplunkStorm.js
+++ b/lib/SplunkStorm.js
@@ -34,7 +34,14 @@ var SplunkStorm = winston.transports.SplunkStorm = function (options) {
 util.inherits(SplunkStorm, winston.Transport)
 
 SplunkStorm.prototype.log = function (level, msg, meta, callback) {
-    this.storm.send(level + " " + msg, this.options.sourcetype, this.options.host, this.options.source, function(err) {
+    var send = {
+        message : msg,
+        level : level
+    }
+
+    for (var attrname in meta) { send[attrname] = meta[attrname]; }
+
+    this.storm.send(send, this.options.sourcetype, this.options.host, this.options.source, function(err) {
 
         callback(err, !err)
 
@@ -52,7 +59,14 @@ SplunkStorm.prototype.log = function (level, msg, meta, callback) {
 * @param callback {function} Continuation to respond to when complete.
 */
 SplunkStorm.prototype.logException = function (msg, meta, callback) {
-    this.storm.send("Exception " + msg, this.options.sourcetype, this.options.host, this.options.source, function(err) {
+    var send = {
+        message : msg,
+        level : 'error'
+    }
+
+    for (var attrname in meta) { send[attrname] = meta[attrname]; }
+
+    this.storm.send(send, this.options.sourcetype, this.options.host, this.options.source, function(err) {
 
         callback(err, !err)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "winston-splunkstorm",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Winston transport for splunkstorm",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Since SplunkStorm can parse json objects we can send a json object. This is benefitial as you can drill down on specific fields in the json objects using the SplunkStorm gui.
