### PR TITLE
Pass options down to base transport class

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var HOST_KEY = 'hst';
  * @constructor
  */
 var WinstonSplunkstorm = function (options) {
-    winston.Transport.call(this);
+    winston.Transport.call(this, options);
 
     options = options || {};
 


### PR DESCRIPTION
Otherwise "level" option isn't set. However, it should be set, because it's a default option for all Winston transports, and Logger Winston class expects the transport to have it.